### PR TITLE
Add puppet-veritas_hyperscale package

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -4141,3 +4141,13 @@ packages:
     under-review:
   maintainers:
   - snecklifter@gmail.com
+- project: puppet-veritas_hyperscale
+  conf: rpmfactory-puppet
+  upstream: https://github.com/vtas-hyperscale-ci/puppet-veritas_hyperscale
+  tags:
+    under-review:
+    #pike:
+  maintainers:
+  - dnyanmpawar@gmail.com
+  - pawarsandeepu@gmail.com
+  - DL-VTAS-ENG-SDIO-HyperScale-Opensource@veritas.com


### PR DESCRIPTION
puppet-veritas_hyperscale includes puppet modules to deploy Veritas
HyperScale.

openstack/puppet-tripleo has added puppet-veritas_hyperscale as
requirement in review https://review.openstack.org/#/c/475762/ .

Package review is in
https://bugzilla.redhat.com/show_bug.cgi?id=1469995.

I'm setting under-review tag until initial import of distgit is done.

Change-Id: Iaeaf609c6810ddd0706d3fc912743d0f62a81796